### PR TITLE
feat(Worldborder): add configurable argument splitter

### DIFF
--- a/WorldBorder/src/com/pixar02/papi/expansion/argument/ArgumentSplitType.java
+++ b/WorldBorder/src/com/pixar02/papi/expansion/argument/ArgumentSplitType.java
@@ -1,0 +1,29 @@
+package com.pixar02.papi.expansion.argument;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.regex.Pattern;
+
+public enum ArgumentSplitType {
+  NO_OMIT("_"),
+  OMIT_PARENTHESIS("_(?![^(]*\\))"),
+  OMIT_SQUARE_BRACKET("_(?![^[]*])"),
+  OMIT_ANGLE_BRACKET("_(?![^{]*})");
+
+  public final static @Nonnull ArgumentSplitType DEFAULT = ArgumentSplitType.OMIT_ANGLE_BRACKET;
+
+  private final @Nonnull String patternString;
+
+  private @Nullable Pattern cachedPattern;
+
+  ArgumentSplitType(@Nonnull String patternString) {
+    this.patternString = patternString;
+  }
+
+  public @Nonnull Pattern getPattern() {
+    if (this.cachedPattern == null) {
+      this.cachedPattern = Pattern.compile(patternString);
+    }
+    return this.cachedPattern;
+  }
+}


### PR DESCRIPTION
Defaults to {} (OMIT_ANGLE_BRACKET), helps to fix issues when using the `fromWorld_{some_world}`  placeholder alongside expansions/plugins that already use brackets to parse internal placeholders, like the Math expansion.